### PR TITLE
Accounting team requirement - Maintenance

### DIFF
--- a/app/Exports/MorphExport.php
+++ b/app/Exports/MorphExport.php
@@ -34,7 +34,29 @@ class MorphExport implements FromCollection, WithHeadings
         if ($this->isExample) {
             return collect([]);
         }
-        return $this->model::all();
+
+        // 取表名
+        $tableName = (new $this->model())->getTable();
+        // 取得client 給的 querystring
+        $qsArr = request()->all();
+        if (! empty($qsArr)) {
+            foreach ($qsArr as $attribute => $value) {
+                // 進入則表示該table內有該 attribute
+                if (Schema::hasColumn($tableName, $attribute)) {
+                    if (! isset($builder)) {
+                        $builder = $this->model::where($attribute,$value);
+                    } else {
+                        $builder->where($attribute,$value);
+                    }
+                }
+            }
+
+            isset($builder) and ($data = $builder->get());
+        }
+
+        return isset($data)
+            ? $data
+            : $this->model::all();
     }
 
     public function headings(): array

--- a/app/Http/Controllers/MaintenanceController.php
+++ b/app/Http/Controllers/MaintenanceController.php
@@ -241,7 +241,8 @@ class MaintenanceController extends Controller
     {
         $room = Maintenance::find($id)->tenantContract->room;
         $records = [];
-        $selectColumns = Maintenance::extraInfoColumns();
+        $columns = array_map(function ($column) { return "maintenances.{$column}"; }, $this->whitelist('maintenances'));
+        $selectColumns = array_merge($columns, Maintenance::extraInfoColumns());
         $selectStr = DB::raw(join(', ', $selectColumns));
 
         $threeMonthsAgo = Carbon::now()->subMonth(3);
@@ -254,9 +255,6 @@ class MaintenanceController extends Controller
                     ->where('payment_request_date', '>', $threeMonthsAgo)
                     ->where('status', '案件完成')
                     ->get()
-                    ->map
-                    // 物件代碼 + 承租方式 + 房號 + 簡稱
-                    ->only(['building_code', 'commission_type', 'room_number', 'building_title'])
                     ->toArray()
             );
         }

--- a/app/Maintenance.php
+++ b/app/Maintenance.php
@@ -39,6 +39,11 @@ class Maintenance extends Model implements AuditableContract
     protected $guarded = [];
 
     protected $hidden = ['pivot', 'deleted_at'];
+
+    protected $casts = [
+        'is_printed' => 'boolean',
+    ];
+
     /**
      * Get the user who took care of this maintenance.
      */

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -38,3 +38,23 @@ if (! function_exists('getLayer')) {
         return $layer;
     }
 }
+
+if (! function_exists('makeArrayToQueryString')) {
+    /**
+     *
+     * @param array $qs 要轉成query string 的陣列
+     *
+     * @return string
+     */
+    function makeArrayToQueryString(array $qs=[]) {
+        if (! empty($qs)) {
+            $tmp = collect($qs)->map(function ($value, $key) {
+                return "{$key}={$value}";
+            })
+                ->toArray();
+            return implode('&', $tmp);
+        }
+
+        return '';
+    }
+}

--- a/config/whitelist.php
+++ b/config/whitelist.php
@@ -24,4 +24,11 @@ return [
     'keys' => [],
     'share_holders' => [],
     'deposits' => [],
+    'maintenances' => [
+        'id', 'tenant_contract_id', 'reported_at', 'expected_service_date', 'expected_service_time', 'dispatch_date',
+        'commissioner_id', 'maintenance_staff_id', 'closed_date', 'closed_comment', 'service_comment', 'status',
+        'incident_details', 'incident_type', 'work_type', 'number_of_times', 'payment_request_date',
+        'closing_serial_number', 'billing_details', 'payment_request_serial_number', 'cost', 'price', 'afford_by',
+        'is_recorded', 'comment', 'created_at', 'updated_at', 'is_printed'
+    ]
 ];

--- a/database/migrations/2019_10_14_145132_add_is_printed_column_to_maintenances_table.php
+++ b/database/migrations/2019_10_14_145132_add_is_printed_column_to_maintenances_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIsPrintedColumnToMaintenancesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('maintenances', function (Blueprint $table) {
+            $table->boolean('is_printed')->default(0)->comment('是否已列印 1:是 0:不是');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('maintenances', function (Blueprint $table) {
+            $table->dropColumn('is_printed');
+        });
+    }
+}

--- a/resources/lang/zh_tw/model.php
+++ b/resources/lang/zh_tw/model.php
@@ -242,6 +242,7 @@ return [
         'room_status' => '房狀態',
         'commission_type' => '承租方式',
         'is_printed' => '是否已列印',
+        'afford_by' => '負擔方',
     ],
     'Appliance' => [
         'id' => '',

--- a/resources/lang/zh_tw/model.php
+++ b/resources/lang/zh_tw/model.php
@@ -241,6 +241,7 @@ return [
         'room_number' => '房號',
         'room_status' => '房狀態',
         'commission_type' => '承租方式',
+        'is_printed' => '是否已列印',
     ],
     'Appliance' => [
         'id' => '',

--- a/resources/views/maintenances/index.blade.php
+++ b/resources/views/maintenances/index.blade.php
@@ -57,7 +57,12 @@
                                 @else
                                     <div class="card-body table-responsive">
                                         <a class="btn btn-sm btn-success my-3" href="{{ route( 'maintenances.create') }}">建立</a>
-                                        @include('shared.import_export_buttons', ['layer' => 'maintenances', 'parentModel' => 'Maintenance', 'parentId' => $data['id'] ?? null])
+                                        @include('shared.import_export_buttons', [
+                                            'layer' => 'maintenances',
+                                            'parentModel' => 'Maintenance',
+                                            'parentId' => $data['id'] ?? null,
+                                            'qs' => ['status'=>$statusName]
+                                        ])
                                         <div class="mb-3">
                                             @if($isAccountGroup && $statusKey == 'request')
                                                 <select class="form-control d-inline-block js-who-undertake" style="width: 100px;">

--- a/resources/views/maintenances/record_modal.blade.php
+++ b/resources/views/maintenances/record_modal.blade.php
@@ -7,12 +7,13 @@
                 <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <div class="modal-body">
+            <div class="modal-body" style="overflow-x: auto">
                 <table id="record-table" class="display table" style="width:100%">
                     <thead>
-                        @foreach ( array_keys($maintenances[0]) as $field)
-                        <th>@lang("model.Maintenance.{$field}")</th>
-                        @endforeach
+                        <th>物件代碼</th>
+                        <th>承租方式</th>
+                        <th>房號</th>
+                        <th>簡稱</th>
                     </thead>
                     <tbody>
                     </tbody>
@@ -24,4 +25,3 @@
         </div>
     </div>
 </div>
-    

--- a/resources/views/maintenances/record_modal.blade.php
+++ b/resources/views/maintenances/record_modal.blade.php
@@ -10,10 +10,9 @@
             <div class="modal-body" style="overflow-x: auto">
                 <table id="record-table" class="display table" style="width:100%">
                     <thead>
-                        <th>物件代碼</th>
-                        <th>承租方式</th>
-                        <th>房號</th>
-                        <th>簡稱</th>
+                    @foreach ( array_keys($maintenances[0]) as $field)
+                        <th>@lang("model.Maintenance.{$field}")</th>
+                    @endforeach
                     </thead>
                     <tbody>
                     </tbody>

--- a/resources/views/shared/import_export_buttons.blade.php
+++ b/resources/views/shared/import_export_buttons.blade.php
@@ -1,13 +1,22 @@
 @php
     $resource = Str::camel(Str::plural($layer));
     $model = ucfirst(Str::camel(Str::singular($layer)));
+
+    // 匯入或匯出需要帶到server上的參數 是一個以 key-value 表示的陣列
+    // 例如qs 要傳送 status= 案件完成 陣列表示為
+    // ['status'=>'案件完成']
+    $queryString = '';
+    if (isset($qs) && is_array($qs)) {
+        $queryString = makeArrayToQueryString($qs);
+    }
+
 @endphp
 
 <a class="btn btn-sm btn-secondary my-3" href="#" data-toggle="modal" data-target="#import-{{$model}}">匯入 Excel</a>
 @if(is_null($parentId))
-    <a class="btn btn-sm btn-secondary my-3" href="/export/{{$model}}">匯出 Excel</a>
+    <a class="btn btn-sm btn-secondary my-3" href="/export/{{$model}}{{ $queryString==='' ? '' : "?{$queryString}" }}">匯出 Excel</a>
 @else
-    <a class="btn btn-sm btn-secondary my-3" href="/export/{{ $parentModel }}/{{  $parentId }}/{{$layer}}">匯出 Excel</a>
+    <a class="btn btn-sm btn-secondary my-3" href="/export/{{ $parentModel }}/{{  $parentId }}/{{$layer}}{{ $queryString==='' ? '' : "?{$queryString}" }}">匯出 Excel</a>
 @endif
 
 @include('shared.import_modal', ['model' => $model])

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,7 +55,7 @@ Route::group(['middleware' => 'internal.protect'], function () {
             Route::resource('shareholders', 'ShareHolderController');
             Route::get('shareholders/export', 'ShareHolderController@exportReport')->name('shareholders.export');
             Route::put('shareholders/{id}/pass', 'EditorialReviewController@pass');
-          
+
             // payments
             Route::get(
                 'tenantElectricityPayments/downloadImportFile',
@@ -103,7 +103,9 @@ Route::group(['middleware' => 'internal.protect'], function () {
 
             // resources API
             Route::post('maintenances/markDone', 'MaintenanceController@markDone');
-            Route::post('maintenances/showRecord', 'MaintenanceController@showRecord');
+            Route::get('maintenances/showRecord/{id}', 'MaintenanceController@showRecord');
+            Route::post('maintenances/checkHasSameWorkType', 'MaintenanceController@checkHasSameWorkType')->name('maintenances.check');
+            Route::post('maintenances/updateIsPrinted', 'MaintenanceController@updateIsPrinted')->name('maintenances.updateIsPrinted');
             Route::get('tenantContracts/{tenantContract}/extend', 'TenantContractController@extend')->name('tenantContracts.extend');
             Route::get('systemVariables', 'SystemVariableController@index')->name('system_variables.index');
             Route::get('systemVariables/{group}', 'SystemVariableController@edit')->name('system_variables.edit');


### PR DESCRIPTION
1. 查看過去紀錄會爆版
2. 過去紀錄，要看到building.物件代碼 + 承租方式 + 房號 + 簡稱，並只顯示『案件完成』的資料
4. 建立維修清潔時，如果三個月內，同 room 有同樣的工種，會詢問使用者要建或不要建，要建才會真的送出
5. 維修清潔模塊，需要匯出 Excel
6. 帳務組審核通過的資料，要能通知管理組，『維修清潔編號{id}已審核完畢』
7. 管理組，案件完成要有類似帳務處批次審查的功能，可以批次將一個欄位『是否已列印』改成是，要新增『是否已列印 is_printed』欄位
8. 負擔方為『房東』的資料，只有帳務權限，可以將狀態從『案件完成』變成『已取消』

另外更改 maintenances/showRecord/{id} 由post改為get